### PR TITLE
adds nodejs version

### DIFF
--- a/test/_node.sh
+++ b/test/_node.sh
@@ -1,0 +1,32 @@
+#! /bin/bash -e
+
+echo "nvm use 4.8.7"
+nvm use 4.8.7
+which node && node -v
+printf "\n"
+
+echo "nvm use 5.12.0"
+nvm use 5.12.0
+which node && node -v
+printf "\n"
+
+echo "nvm use 6.11.5"
+nvm use 6.11.5
+which node && node -v
+printf "\n"
+
+echo "nvm use 7.10.1"
+nvm use 7.10.1
+which node && node -v
+printf "\n"
+
+echo "nvm use 8.9.4"
+nvm use 8.9.4
+which node && node -v
+printf "\n"
+
+echo "nvm use 9.5.0"
+nvm use 9.5.0
+which node && node -v
+printf "\n"
+

--- a/version/4_8_7.sh
+++ b/version/4_8_7.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+NODE_VERSION=4.8.7
+NPM_VERSION=5.6.0
+echo "=============== Installing Node $NODE_VERSION ============="
+. /root/.nvm/nvm.sh && nvm install $NODE_VERSION
+nvm use $NODE_VERSION && npm install npm@$NPM_VERSION -g
+

--- a/version/5_12_0.sh
+++ b/version/5_12_0.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+echo "=============== Installing Node v. 5.12.0 ============="
+. /root/.nvm/nvm.sh && nvm install 5.12.0

--- a/version/6_11_5.sh
+++ b/version/6_11_5.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+NODE_VERSION=6.11.5
+NPM_VERSION=5.6.0
+echo "=============== Installing Node $NODE_VERSION ============="
+. /root/.nvm/nvm.sh && nvm install $NODE_VERSION
+nvm use $NODE_VERSION && npm install npm@$NPM_VERSION -g
+

--- a/version/7_10_1.sh
+++ b/version/7_10_1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+echo "=============== Installing Node v. 7.x ============="
+. /root/.nvm/nvm.sh && nvm install 7.10.1

--- a/version/8_9_4.sh
+++ b/version/8_9_4.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+NODE_VERSION=8.9.4
+NPM_VERSION=5.6.0
+echo "=============== Installing Node $NODE_VERSION ============="
+. /root/.nvm/nvm.sh && nvm install $NODE_VERSION
+nvm use $NODE_VERSION && npm install npm@$NPM_VERSION -g
+

--- a/version/9_5_0.sh
+++ b/version/9_5_0.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+NODE_VERSION=9.5.0
+NPM_VERSION=5.6.0
+echo "=============== Installing Node $NODE_VERSION ============="
+. /root/.nvm/nvm.sh && nvm install $NODE_VERSION
+nvm use $NODE_VERSION && npm install npm@$NPM_VERSION -g
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16nodall/issues/8
https://github.com/dry-dock-aarch64/u16nodall/issues/7
https://github.com/dry-dock-aarch64/u16nodall/issues/6
https://github.com/dry-dock-aarch64/u16nodall/issues/5
https://github.com/dry-dock-aarch64/u16nodall/issues/4
https://github.com/dry-dock-aarch64/u16nodall/issues/3

installs node_js versions same as x86_64
```
root@6dfcdc66a407:/# /u16nodall/test/_node.sh 
nvm use 4.8.7
Now using node v4.8.7 (npm v5.6.0)
/root/.nvm/versions/node/v4.8.7/bin/node
v4.8.7

nvm use 5.12.0
Now using node v5.12.0 (npm v3.8.6)
/root/.nvm/versions/node/v5.12.0/bin/node
v5.12.0

nvm use 6.11.5
Now using node v6.11.5 (npm v5.6.0)
/root/.nvm/versions/node/v6.11.5/bin/node
v6.11.5

nvm use 7.10.1
Now using node v7.10.1 (npm v4.2.0)
/root/.nvm/versions/node/v7.10.1/bin/node
v7.10.1

nvm use 8.9.4
Now using node v8.9.4 (npm v5.6.0)
/root/.nvm/versions/node/v8.9.4/bin/node
v8.9.4

nvm use 9.5.0
Now using node v9.5.0 (npm v5.6.0)
/root/.nvm/versions/node/v9.5.0/bin/node
v9.5.0
```


